### PR TITLE
Add test for steer drive controller

### DIFF
--- a/steer_drive_controller/CMakeLists.txt
+++ b/steer_drive_controller/CMakeLists.txt
@@ -2,31 +2,31 @@ cmake_minimum_required(VERSION 2.8.3)
 project(steer_drive_controller)
 
 find_package(catkin REQUIRED COMPONENTS
-    controller_interface
-    urdf
-    realtime_tools
-    tf
-    nav_msgs
-    roscpp
-    angles
-    control_toolbox
-    gazebo_ros_control
-    hardware_interface
-    joint_limits_interface
+  controller_interface
+  urdf
+  realtime_tools
+  tf
+  nav_msgs
+  roscpp
+  angles
+  control_toolbox
+  gazebo_ros_control
+  hardware_interface
+  joint_limits_interface
 )
 
 find_package(gazebo REQUIRED)
 
 catkin_package(
-    INCLUDE_DIRS include
-    LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS
-    roscpp
-    angles
-    control_toolbox
-    gazebo_ros_control
-    hardware_interface
-    joint_limits_interface
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS
+  roscpp
+  angles
+  control_toolbox
+  gazebo_ros_control
+  hardware_interface
+  joint_limits_interface
 )
 
 include_directories(
@@ -43,10 +43,10 @@ install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
+)
 
 install(FILES steer_drive_controller_plugins.xml
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS

--- a/steer_drive_controller/CMakeLists.txt
+++ b/steer_drive_controller/CMakeLists.txt
@@ -21,12 +21,12 @@ catkin_package(
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
     CATKIN_DEPENDS
-      roscpp
-      angles
-      control_toolbox
-      gazebo_ros_control
-      hardware_interface
-      joint_limits_interface
+    roscpp
+    angles
+    control_toolbox
+    gazebo_ros_control
+    hardware_interface
+    joint_limits_interface
 )
 
 include_directories(
@@ -48,59 +48,21 @@ install(TARGETS ${PROJECT_NAME}
 install(FILES steer_drive_controller_plugins.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-add_executable(steer_drive_test test/steer_drive_test.cpp src/steer_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
-target_link_libraries(steer_drive_test ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
-
 if (CATKIN_ENABLE_TESTING)
-#  find_package(catkin COMPONENTS rostest std_srvs controller_manager tf)
-#  include_directories(include ${catkin_INCLUDE_DIRS})
-#
-#  #  add_executable(steer_drive_bot test/diffbot.cpp)
-#  #  target_link_libraries(steer_drive_bot ${catkin_LIBRARIES})
-#
-#  add_executable(steer_drive_bot test/skidsteerbot.cpp)
-#  target_link_libraries(steer_drive_bot ${catkin_LIBRARIES})
+  find_package(catkin COMPONENTS rostest std_srvs controller_manager tf)
+  include_directories(include ${catkin_INCLUDE_DIRS})
 
+  add_executable(steerbot test/common/src/steerbot.cpp)
+  target_link_libraries(steerbot ${catkin_LIBRARIES})
+
+  add_dependencies(tests steerbot)
+
+  add_rostest_gtest(steer_drive_test
+    test/steer_drive_controller.test
+    test/steer_drive_test.cpp)
+  target_link_libraries(steer_drive_test ${catkin_LIBRARIES})
+  add_rostest_gtest(steer_drive_nan_test
+    test/steer_drive_controller_nan.test
+    test/steer_drive_nan_test.cpp)
+  target_link_libraries(steer_drive_nan_test ${catkin_LIBRARIES})
 endif()
-#  add_dependencies(tests diffbot skidsteerbot)
-#  add_rostest_gtest(diff_drive_test
-#    test/diff_drive_controller.test
-#    test/diff_drive_test.cpp)
-#  target_link_libraries(diff_drive_test ${catkin_LIBRARIES})
-#  add_rostest_gtest(diff_drive_nan_test
-#    test/diff_drive_controller_nan.test
-#    test/diff_drive_nan_test.cpp)
-#  target_link_libraries(diff_drive_nan_test ${catkin_LIBRARIES})
-#  add_rostest_gtest(diff_drive_limits_test
-#    test/diff_drive_controller_limits.test
-#    test/diff_drive_limits_test.cpp)
-#  target_link_libraries(diff_drive_limits_test ${catkin_LIBRARIES})
-#  add_rostest_gtest(diff_drive_timeout_test
-#    test/diff_drive_timeout.test
-#    test/diff_drive_timeout_test.cpp)
-#  target_link_libraries(diff_drive_timeout_test ${catkin_LIBRARIES})
-#  add_rostest(test/diff_drive_multipliers.test)
-#  add_rostest_gtest(diff_drive_fail_test
-#    test/diff_drive_wrong.test
-#    test/diff_drive_fail_test.cpp)
-#  target_link_libraries(diff_drive_fail_test ${catkin_LIBRARIES})
-#  add_rostest_gtest(diff_drive_odom_tf_test
-#    test/diff_drive_odom_tf.test
-#    test/diff_drive_odom_tf_test.cpp)
-#  target_link_libraries(diff_drive_odom_tf_test ${catkin_LIBRARIES})
-#  add_rostest_gtest(diff_drive_default_odom_frame_test
-#    test/diff_drive_default_odom_frame.test
-#    test/diff_drive_default_odom_frame_test.cpp)
-#  target_link_libraries(diff_drive_default_odom_frame_test ${catkin_LIBRARIES})
-#  add_rostest_gtest(diff_drive_odom_frame_test
-#    test/diff_drive_odom_frame.test
-#    test/diff_drive_odom_frame_test.cpp)
-#  target_link_libraries(diff_drive_odom_frame_test ${catkin_LIBRARIES})
-#  add_rostest(test/diff_drive_open_loop.test)
-#  add_rostest(test/skid_steer_controller.test)
-#  add_rostest(test/skid_steer_no_wheels.test)
-#  add_rostest(test/diff_drive_radius_param.test)
-#  add_rostest(test/diff_drive_radius_param_fail.test)
-#  add_rostest(test/diff_drive_separation_param.test)
-#  add_rostest(test/diff_drive_bad_urdf.test)
-#endif()

--- a/steer_drive_controller/CMakeLists.txt
+++ b/steer_drive_controller/CMakeLists.txt
@@ -49,7 +49,12 @@ install(FILES steer_drive_controller_plugins.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(catkin COMPONENTS rostest std_srvs controller_manager tf)
+  find_package(catkin REQUIRED COMPONENTS
+    rostest
+    std_srvs
+    controller_manager
+    tf
+  )
   include_directories(include ${catkin_INCLUDE_DIRS})
 
   add_executable(steerbot test/common/src/steerbot.cpp)

--- a/steer_drive_controller/include/steer_drive_controller/steer_drive_controller.h
+++ b/steer_drive_controller/include/steer_drive_controller/steer_drive_controller.h
@@ -167,10 +167,8 @@ namespace steer_drive_controller{
     double wheel_radius_;
 
     /// Wheel separation and radius calibration multipliers:
-    double wheel_separation_w_multiplier_;
-    double wheel_separation_h_multiplier_;
+    double wheel_separation_multiplier_;
     double wheel_radius_multiplier_;
-    double steer_pos_multiplier_;
 
     /// Timeout to consider cmd_vel commands old:
     double cmd_vel_timeout_;

--- a/steer_drive_controller/include/steer_drive_controller/steer_drive_controller.h
+++ b/steer_drive_controller/include/steer_drive_controller/steer_drive_controller.h
@@ -167,8 +167,10 @@ namespace steer_drive_controller{
     double wheel_radius_;
 
     /// Wheel separation and radius calibration multipliers:
-    double wheel_separation_multiplier_;
+    double wheel_separation_w_multiplier_;
+    double wheel_separation_h_multiplier_;
     double wheel_radius_multiplier_;
+    double steer_pos_multiplier_;
 
     /// Timeout to consider cmd_vel commands old:
     double cmd_vel_timeout_;

--- a/steer_drive_controller/package.xml
+++ b/steer_drive_controller/package.xml
@@ -32,6 +32,8 @@
   <build_depend>rostest</build_depend>
 
   <test_depend>controller_manager</test_depend>
+  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>xacro</test_depend>
 

--- a/steer_drive_controller/src/steer_drive_controller.cpp
+++ b/steer_drive_controller/src/steer_drive_controller.cpp
@@ -324,6 +324,9 @@ namespace steer_drive_controller{
       double right_pos = rear_wheel_joints_[INDEX_RIGHT].getPosition();
       double steer_pos = steer_joint_.getPosition();
 
+      if (std::isnan(left_pos) || std::isnan(right_pos) || std::isnan(steer_pos))
+        return;
+
       // Estimate linear and angular velocity using joint information
       steer_pos = steer_pos * steer_pos_multiplier_;
       odometry_.update(left_pos, right_pos, steer_pos, time);

--- a/steer_drive_controller/src/steer_drive_controller.cpp
+++ b/steer_drive_controller/src/steer_drive_controller.cpp
@@ -113,10 +113,8 @@ namespace steer_drive_controller{
     , wheel_separation_w_(0.0)
     , wheel_separation_h_(0.0)
     , wheel_radius_(0.0)
-    , wheel_separation_w_multiplier_(1.0)
-    , wheel_separation_h_multiplier_(1.0)
+    , wheel_separation_multiplier_(1.0)
     , wheel_radius_multiplier_(1.0)
-    , steer_pos_multiplier_(1.0)
     , cmd_vel_timeout_(0.5)
     , allow_multiple_cmd_vel_publishers_(true)
     , base_frame_id_("base_link")
@@ -192,21 +190,13 @@ namespace steer_drive_controller{
 
     controller_nh.param(ns_ + "open_loop", open_loop_, open_loop_);
 
-    controller_nh.param(ns_ + "wheel_separation_w_multiplier", wheel_separation_w_multiplier_, wheel_separation_w_multiplier_);
-    ROS_INFO_STREAM_NAMED(name_, "Wheel separation width will be multiplied by "
-                          << wheel_separation_w_multiplier_ << ".");
-
-    controller_nh.param(ns_ + "wheel_separation_h_multiplier", wheel_separation_h_multiplier_, wheel_separation_h_multiplier_);
-    ROS_INFO_STREAM_NAMED(name_, "Wheel separation height will be multiplied by "
-                          << wheel_separation_h_multiplier_ << ".");
+    controller_nh.param(ns_ + "wheel_separation_multiplier", wheel_separation_multiplier_, wheel_separation_multiplier_);
+    ROS_INFO_STREAM_NAMED(name_, "Wheel separation will be multiplied by "
+                          << wheel_separation_multiplier_ << ".");
 
     controller_nh.param(ns_ + "wheel_radius_multiplier", wheel_radius_multiplier_, wheel_radius_multiplier_);
     ROS_INFO_STREAM_NAMED(name_, "Wheel radius will be multiplied by "
                           << wheel_radius_multiplier_ << ".");
-
-    controller_nh.param(ns_ + "steer_pos_multiplier", steer_pos_multiplier_, steer_pos_multiplier_);
-    ROS_INFO_STREAM_NAMED(name_, "Steer pos will be multiplied by "
-                          << steer_pos_multiplier_ << ".");
 
     int velocity_rolling_window_size = 10;
     controller_nh.param(ns_ + "velocity_rolling_window_size", velocity_rolling_window_size, velocity_rolling_window_size);
@@ -272,8 +262,8 @@ namespace steer_drive_controller{
 
     // Regardless of how we got the separation and radius, use them
     // to set the odometry parameters
-    const double ws_w = wheel_separation_w_multiplier_ * wheel_separation_w_;
-    const double ws_h = wheel_separation_h_multiplier_ * wheel_separation_h_;
+    const double ws_w = wheel_separation_multiplier_ * wheel_separation_w_;
+    const double ws_h = wheel_separation_multiplier_ * wheel_separation_h_;
     const double wr = wheel_radius_multiplier_     * wheel_radius_;
     odometry_.setWheelParams(ws_w, ws_h, wr);
     ROS_INFO_STREAM_NAMED(name_,
@@ -324,8 +314,10 @@ namespace steer_drive_controller{
       double right_pos = rear_wheel_joints_[INDEX_RIGHT].getPosition();
       double steer_pos = steer_joint_.getPosition();
 
+      if (std::isnan(left_pos) || std::isnan(right_pos) || std::isnan(steer_pos))
+          return;
+
       // Estimate linear and angular velocity using joint information
-      steer_pos = steer_pos * steer_pos_multiplier_;
       odometry_.update(left_pos, right_pos, steer_pos, time);
     }
 

--- a/steer_drive_controller/test/common/config/steerbot_controllers.yaml
+++ b/steer_drive_controller/test/common/config/steerbot_controllers.yaml
@@ -1,0 +1,17 @@
+
+steerbot_controller:
+  type: "steer_drive_controller/SteerDriveController"
+  rear_wheel  : 'base_to_wheel'
+  front_steer : 'base_to_steer'
+  rear_wheels: ['rear_right_wheel_joint', 'rear_left_wheel_joint']
+  front_wheels: ['front_right_wheel_joint', 'front_left_wheel_joint']
+  front_steers: ['front_right_steer_joint', 'front_left_steer_joint']
+  publish_rate: 50.0 # defaults to 50
+
+  pose_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+  twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+  cmd_vel_timeout: 20.0 # we test this separately, give plenty for the other tests
+
+  wheel_separation_w : 0.5
+  wheel_separation_h : 0.79
+  wheel_radius : 0.28

--- a/steer_drive_controller/test/common/include/steerbot.h
+++ b/steer_drive_controller/test/common/include/steerbot.h
@@ -1,0 +1,431 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// NOTE: The contents of this file have been taken largely from the ros_control wiki tutorials
+
+// ROS
+#include <ros/ros.h>
+#include <std_msgs/Float64.h>
+#include <std_srvs/Empty.h>
+
+// ros_control
+#include <controller_manager/controller_manager.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/robot_hw.h>
+#include <realtime_tools/realtime_buffer.h>
+
+// NaN
+#include <limits>
+
+// ostringstream
+#include <sstream>
+
+enum INDEX_WHEEL {
+    INDEX_RIGHT = 0,
+    INDEX_LEFT = 1
+};
+
+class Steerbot : public hardware_interface::RobotHW
+{
+public:
+  Steerbot()
+  : running_(true)
+  , start_srv_(nh_.advertiseService("start", &Steerbot::startCallback, this))
+  , stop_srv_(nh_.advertiseService("stop", &Steerbot::stopCallback, this))
+  , ns_("steerbot_controller/")
+  {
+    // Intialize raw data
+    this->cleanUp();
+    this->getJointNames(nh_);
+    this->registerHardwareInterfaces();
+
+    nh_.getParam(ns_ + "wheel_separation_w", wheel_separation_w_);
+    nh_.getParam(ns_ + "wheel_separation_h", wheel_separation_h_);
+    ROS_INFO_STREAM("wheel_separation_w in test steerbot= " << wheel_separation_w_);
+    ROS_INFO_STREAM("wheel_separation_h in test steerbot= " << wheel_separation_h_);
+  }
+
+  ros::Time getTime() const {return ros::Time::now();}
+  ros::Duration getPeriod() const {return ros::Duration(0.01);}
+
+  void read()
+  {
+    std::ostringstream os;
+    // directly get from controller
+    os << wheel_jnt_vel_cmd_ << ", ";
+    os << steer_jnt_pos_cmd_ << ", ";
+
+    // convert to each joint velocity
+    //-- differential drive
+    for (unsigned int i = 0; i < virtual_rear_wheel_jnt_vel_cmd_.size(); i++)
+    {
+      virtual_rear_wheel_jnt_vel_cmd_[i] = wheel_jnt_vel_cmd_;
+      os << virtual_rear_wheel_jnt_vel_cmd_[i] << ", ";
+    }
+
+    //-- ackerman link
+    const double h = wheel_separation_h_;
+    const double w = wheel_separation_w_;
+    virtual_steer_jnt_pos_cmd_[INDEX_RIGHT] = atan2(2*h*tan(steer_jnt_pos_cmd_), 2*h + w/2.0*tan(steer_jnt_pos_cmd_));
+    virtual_steer_jnt_pos_cmd_[INDEX_LEFT] = atan2(2*h*tan(steer_jnt_pos_cmd_), 2*h - w/2.0*tan(steer_jnt_pos_cmd_));
+
+    for (unsigned int i = 0; i < virtual_steer_jnt_pos_cmd_.size(); i++)
+    {
+      os << virtual_steer_jnt_pos_cmd_[i] << ", ";
+    }
+
+    if (wheel_jnt_vel_cmd_ != 0.0 || steer_jnt_pos_cmd_ != 0.0)
+      ROS_INFO_STREAM("Commands for joints: " << os.str());
+
+  }
+
+  void write()
+  {
+    std::ostringstream os;
+    if (running_)
+    {
+      // wheels
+      for (unsigned int i = 0; i < virtual_rear_wheel_jnt_vel_cmd_.size(); i++)
+      {
+        // Note that pos_[i] will be NaN for one more cycle after we start(),
+        // but that is consistent with the knowledge we have about the state
+        // of the robot.
+        virtual_rear_wheel_jnt_pos_[i] += virtual_rear_wheel_jnt_vel_[i]*getPeriod().toSec();
+        virtual_rear_wheel_jnt_vel_[i] = virtual_rear_wheel_jnt_vel_cmd_[i];
+      }
+
+      // steers
+      for (unsigned int i = 0; i < virtual_steer_jnt_pos_cmd_.size(); i++)
+      {
+        virtual_steer_jnt_pos_[i] = virtual_steer_jnt_pos_cmd_[i];
+      }
+
+      // directly get from controller
+      os << wheel_jnt_vel_cmd_ << ", ";
+      os << steer_jnt_pos_cmd_ << ", ";
+
+      // convert to each joint velocity
+      //-- differential drive
+      for (unsigned int i = 0; i < virtual_rear_wheel_jnt_pos_.size(); i++)
+      {
+          os << virtual_rear_wheel_jnt_pos_[i] << ", ";
+      }
+
+      //-- ackerman link
+      for (unsigned int i = 0; i < virtual_steer_jnt_pos_.size(); i++)
+      {
+          os << virtual_steer_jnt_pos_[i] << ", ";
+      }
+    }
+    else
+    {
+      // wheels
+      wheel_jnt_pos_= std::numeric_limits<double>::quiet_NaN();
+      wheel_jnt_vel_= std::numeric_limits<double>::quiet_NaN();
+      std::fill_n(virtual_rear_wheel_jnt_pos_.begin(), virtual_rear_wheel_jnt_pos_.size(), std::numeric_limits<double>::quiet_NaN());
+      std::fill_n(virtual_rear_wheel_jnt_vel_.begin(), virtual_rear_wheel_jnt_vel_.size(), std::numeric_limits<double>::quiet_NaN());
+      // steers
+      steer_jnt_pos_= std::numeric_limits<double>::quiet_NaN();
+      steer_jnt_vel_= std::numeric_limits<double>::quiet_NaN();
+      std::fill_n(virtual_steer_jnt_pos_.begin(), virtual_steer_jnt_pos_.size(), std::numeric_limits<double>::quiet_NaN());
+      std::fill_n(virtual_steer_jnt_vel_.begin(), virtual_steer_jnt_vel_.size(), std::numeric_limits<double>::quiet_NaN());
+
+      // wheels
+      os << wheel_jnt_pos_ << ", ";
+      os << wheel_jnt_vel_ << ", ";
+      for (unsigned int i = 0; i < virtual_rear_wheel_jnt_pos_.size(); i++)
+      {
+          os << virtual_rear_wheel_jnt_pos_[i] << ", ";
+      }
+
+      // steers
+      os << steer_jnt_pos_ << ", ";
+      os << steer_jnt_vel_ << ", ";
+      for (unsigned int i = 0; i < virtual_steer_jnt_pos_.size(); i++)
+      {
+          os << virtual_steer_jnt_pos_[i] << ", ";
+      }
+    }
+    ROS_INFO_STREAM("running_ = " << running_ << ". commands are " << os.str());
+  }
+
+  bool startCallback(std_srvs::Empty::Request& /*req*/, std_srvs::Empty::Response& /*res*/)
+  {
+    ROS_INFO_STREAM("running_ = " << running_ << ".");
+    running_ = true;
+    return true;
+  }
+
+  bool stopCallback(std_srvs::Empty::Request& /*req*/, std_srvs::Empty::Response& /*res*/)
+  {
+    ROS_INFO_STREAM("running_ = " << running_ << ".");
+    running_ = false;
+    return true;
+  }
+
+private:
+  
+  void cleanUp()
+  {
+    // wheel
+    //-- wheel joint names
+    wheel_jnt_name_.empty();
+    virtual_rear_wheel_jnt_names_.clear();
+    //-- actual rear wheel joint
+    wheel_jnt_pos_ = 0;
+    wheel_jnt_vel_ = 0;
+    wheel_jnt_eff_ = 0;
+    wheel_jnt_vel_cmd_ = 0;
+    //-- virtual rear wheel joint
+    virtual_rear_wheel_jnt_pos_.clear();
+    virtual_rear_wheel_jnt_vel_.clear();
+    virtual_rear_wheel_jnt_eff_.clear();
+    virtual_rear_wheel_jnt_vel_cmd_.clear();
+    //-- virtual front wheel joint
+    virtual_front_wheel_jnt_pos_.clear();
+    virtual_front_wheel_jnt_vel_.clear();
+    virtual_front_wheel_jnt_eff_.clear();
+    virtual_front_wheel_jnt_vel_cmd_.clear();
+
+    // steer
+    //-- steer joint names
+    steer_jnt_name_.empty();
+    virtual_steer_jnt_names_.clear();
+    //-- front steer joint
+    steer_jnt_pos_ = 0;
+    steer_jnt_vel_ = 0;
+    steer_jnt_eff_ = 0;
+    steer_jnt_pos_cmd_ = 0;
+    //-- virtual wheel joint
+    virtual_steer_jnt_pos_.clear();
+    virtual_steer_jnt_vel_.clear();
+    virtual_steer_jnt_eff_.clear();
+    virtual_steer_jnt_pos_cmd_.clear();
+  }
+
+  void getJointNames(ros::NodeHandle &_nh)
+  {
+    this->getWheelJointNames(_nh);
+    this->getSteerJointNames(_nh);
+  }
+
+  void getWheelJointNames(ros::NodeHandle &_nh)
+  {
+    // wheel joint to get linear command
+    _nh.getParam(ns_ + "rear_wheel", wheel_jnt_name_);
+
+    // virtual wheel joint for gazebo control
+    _nh.getParam(ns_ + "rear_wheels", virtual_rear_wheel_jnt_names_);
+    int dof = virtual_rear_wheel_jnt_names_.size();
+    virtual_rear_wheel_jnt_pos_.resize(dof);
+    virtual_rear_wheel_jnt_vel_.resize(dof);
+    virtual_rear_wheel_jnt_eff_.resize(dof);
+    virtual_rear_wheel_jnt_vel_cmd_.resize(dof);
+
+    _nh.getParam(ns_ + "front_wheels", virtual_front_wheel_jnt_names_);
+    dof = virtual_front_wheel_jnt_names_.size();
+    virtual_front_wheel_jnt_pos_.resize(dof);
+    virtual_front_wheel_jnt_vel_.resize(dof);
+    virtual_front_wheel_jnt_eff_.resize(dof);
+    virtual_front_wheel_jnt_vel_cmd_.resize(dof);
+  }
+
+  void getSteerJointNames(ros::NodeHandle &_nh)
+  {
+    // steer joint to get angular command
+    _nh.getParam(ns_ + "front_steer", steer_jnt_name_);
+
+    // virtual steer joint for gazebo control
+    _nh.getParam(ns_ + "front_steers", virtual_steer_jnt_names_);
+
+    const int dof = virtual_steer_jnt_names_.size();
+    virtual_steer_jnt_pos_.resize(dof);
+    virtual_steer_jnt_vel_.resize(dof);
+    virtual_steer_jnt_eff_.resize(dof);
+    virtual_steer_jnt_pos_cmd_.resize(dof);
+  }
+
+  void registerHardwareInterfaces()
+  {
+    this->registerSteerInterface();
+    this->registerWheelInterface();
+
+    // register mapped interface to ros_control
+    registerInterface(&jnt_state_interface_);
+    registerInterface(&wheel_jnt_vel_cmd_interface_);
+    registerInterface(&steer_jnt_pos_cmd_interface_);
+  }
+
+  void registerWheelInterface()
+  {
+    // actual wheel joints
+    this->registerInterfaceHandles(
+          jnt_state_interface_, wheel_jnt_vel_cmd_interface_,
+          wheel_jnt_name_, wheel_jnt_pos_, wheel_jnt_vel_, wheel_jnt_eff_, wheel_jnt_vel_cmd_);
+
+    // virtual rear wheel joints
+    for (int i = 0; i < virtual_rear_wheel_jnt_names_.size(); i++)
+    {
+      this->registerInterfaceHandles(
+            jnt_state_interface_, wheel_jnt_vel_cmd_interface_,
+            virtual_rear_wheel_jnt_names_[i], virtual_rear_wheel_jnt_pos_[i], virtual_rear_wheel_jnt_vel_[i], virtual_rear_wheel_jnt_eff_[i], virtual_rear_wheel_jnt_vel_cmd_[i]);
+    }
+    // virtual front wheel joints
+    for (int i = 0; i < virtual_front_wheel_jnt_names_.size(); i++)
+    {
+      this->registerInterfaceHandles(
+            jnt_state_interface_, wheel_jnt_vel_cmd_interface_,
+            virtual_front_wheel_jnt_names_[i], virtual_front_wheel_jnt_pos_[i], virtual_front_wheel_jnt_vel_[i], virtual_front_wheel_jnt_eff_[i], virtual_front_wheel_jnt_vel_cmd_[i]);
+    }
+  }
+
+  void registerSteerInterface()
+  {
+    // actual steer joints
+    this->registerInterfaceHandles(
+          jnt_state_interface_, steer_jnt_pos_cmd_interface_,
+          steer_jnt_name_, steer_jnt_pos_, steer_jnt_vel_, steer_jnt_eff_, steer_jnt_pos_cmd_);
+
+    // virtual steer joints
+    for (int i = 0; i < virtual_steer_jnt_names_.size(); i++)
+    {
+      this->registerInterfaceHandles(
+            jnt_state_interface_, steer_jnt_pos_cmd_interface_,
+            virtual_steer_jnt_names_[i], virtual_steer_jnt_pos_[i], virtual_steer_jnt_vel_[i], virtual_steer_jnt_eff_[i], virtual_steer_jnt_pos_cmd_[i]);
+    }
+  }
+
+  void registerInterfaceHandles(
+          hardware_interface::JointStateInterface& _jnt_state_interface,
+          hardware_interface::JointCommandInterface& _jnt_cmd_interface,
+          const std::string _jnt_name, double& _jnt_pos, double& _jnt_vel, double& _jnt_eff,  double& _jnt_cmd)
+  {
+    // register joint (both JointState and CommandJoint)
+    this->registerJointStateInterfaceHandle(_jnt_state_interface, _jnt_name,
+                                            _jnt_pos, _jnt_vel, _jnt_eff);
+    this->registerCommandJointInterfaceHandle(_jnt_state_interface, _jnt_cmd_interface,
+                                              _jnt_name, _jnt_cmd);
+  }
+
+  void registerJointStateInterfaceHandle(
+      hardware_interface::JointStateInterface& _jnt_state_interface,
+      const std::string _jnt_name, double& _jnt_pos, double& _jnt_vel, double& _jnt_eff)
+  {
+    hardware_interface::JointStateHandle state_handle(_jnt_name,
+                                                      &_jnt_pos,
+                                                      &_jnt_vel,
+                                                      &_jnt_eff);
+    _jnt_state_interface.registerHandle(state_handle);
+
+    ROS_INFO_STREAM("Registered joint '" << _jnt_name << " ' in the JointStateInterface");
+  }
+
+  void registerCommandJointInterfaceHandle(
+      hardware_interface::JointStateInterface& _jnt_state_interface,
+      hardware_interface::JointCommandInterface& _jnt_cmd_interface,
+      const std::string _jnt_name, double& _jnt_cmd)
+  {
+    // joint command
+    hardware_interface::JointHandle _handle(_jnt_state_interface.getHandle(_jnt_name),
+                                            &_jnt_cmd);
+    _jnt_cmd_interface.registerHandle(_handle);
+
+    ROS_INFO_STREAM("Registered joint '" << _jnt_name << " ' in the CommandJointInterface");
+  }
+
+private:
+  // common
+  hardware_interface::JointStateInterface jnt_state_interface_;// rear wheel
+  //-- actual joint(single actuator)
+  //---- joint name
+  std::string wheel_jnt_name_;
+  //---- joint interface parameters
+  double wheel_jnt_pos_;
+  double wheel_jnt_vel_;
+  double wheel_jnt_eff_;
+  //---- joint interface command
+  double wheel_jnt_vel_cmd_;
+  //---- Hardware interface: joint
+  hardware_interface::VelocityJointInterface wheel_jnt_vel_cmd_interface_;
+  //hardware_interface::JointStateInterface wheel_jnt_state_interface_;
+  //
+  //-- virtual joints(two rear wheels)
+  //---- joint name
+  std::vector<std::string> virtual_rear_wheel_jnt_names_;
+  //---- joint interface parameters
+  std::vector<double> virtual_rear_wheel_jnt_pos_;
+  std::vector<double> virtual_rear_wheel_jnt_vel_;
+  std::vector<double> virtual_rear_wheel_jnt_eff_;
+  //---- joint interface command
+  std::vector<double> virtual_rear_wheel_jnt_vel_cmd_;
+  //-- virtual joints(two front wheels)
+  //---- joint name
+  std::vector<std::string> virtual_front_wheel_jnt_names_;
+  //---- joint interface parameters
+  std::vector<double> virtual_front_wheel_jnt_pos_;
+  std::vector<double> virtual_front_wheel_jnt_vel_;
+  std::vector<double> virtual_front_wheel_jnt_eff_;
+  //---- joint interface command
+  std::vector<double> virtual_front_wheel_jnt_vel_cmd_;
+
+  // front steer
+  //-- actual joint(single actuator)
+  //---- joint name
+  std::string steer_jnt_name_;
+  //---- joint interface parameters
+  double steer_jnt_pos_;
+  double steer_jnt_vel_;
+  double steer_jnt_eff_;
+  //---- joint interface command
+  double steer_jnt_pos_cmd_;
+  //---- Hardware interface: joint
+  hardware_interface::PositionJointInterface steer_jnt_pos_cmd_interface_;
+  //hardware_interface::JointStateInterface steer_jnt_state_interface_;
+  //
+  //-- virtual joints(two steers)
+  //---- joint name
+  std::vector<std::string> virtual_steer_jnt_names_;
+  //---- joint interface parameters
+  std::vector<double> virtual_steer_jnt_pos_;
+  std::vector<double> virtual_steer_jnt_vel_;
+  std::vector<double> virtual_steer_jnt_eff_;
+  //---- joint interface command
+  std::vector<double> virtual_steer_jnt_pos_cmd_;
+
+  // Wheel separation, wrt the midpoint of the wheel width:
+  double wheel_separation_w_;
+  // Wheel separation, wrt the midpoint of the wheel width:
+  double wheel_separation_h_;
+
+  std::string ns_;
+  bool running_;
+
+  ros::NodeHandle nh_;
+  ros::ServiceServer start_srv_;
+  ros::ServiceServer stop_srv_;
+};

--- a/steer_drive_controller/test/common/include/test_common.h
+++ b/steer_drive_controller/test/common/include/test_common.h
@@ -1,0 +1,96 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Bence Magyar
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include <ros/ros.h>
+
+#include <geometry_msgs/Twist.h>
+#include <nav_msgs/Odometry.h>
+#include <tf/tf.h>
+
+#include <std_srvs/Empty.h>
+
+// Floating-point value comparison threshold
+const double EPS = 0.01;
+const double POSITION_TOLERANCE = 0.01; // 1 cm-s precision
+const double VELOCITY_TOLERANCE = 0.02; // 2 cm-s-1 precision
+const double JERK_LINEAR_VELOCITY_TOLERANCE = 0.10; // 10 cm-s-1 precision
+const double JERK_ANGULAR_VELOCITY_TOLERANCE = 0.05; // 3 deg-s-1 precision
+const double ORIENTATION_TOLERANCE = 0.03; // 0.57 degree precision
+
+class SteerDriveControllerTest : public ::testing::Test
+{
+public:
+
+  SteerDriveControllerTest()
+  : cmd_pub(nh.advertise<geometry_msgs::Twist>("cmd_vel", 100))
+  , odom_sub(nh.subscribe("odom", 100, &SteerDriveControllerTest::odomCallback, this))
+  , start_srv(nh.serviceClient<std_srvs::Empty>("start"))
+  , stop_srv(nh.serviceClient<std_srvs::Empty>("stop"))
+  {
+  }
+
+  ~SteerDriveControllerTest()
+  {
+    odom_sub.shutdown();
+  }
+
+  nav_msgs::Odometry getLastOdom(){ return last_odom; }
+  void publish(geometry_msgs::Twist cmd_vel){ cmd_pub.publish(cmd_vel); }
+  bool isControllerAlive(){ return (odom_sub.getNumPublishers() > 0) && (cmd_pub.getNumSubscribers() > 0); }
+
+  void start(){ std_srvs::Empty srv; start_srv.call(srv); }
+  void stop(){ std_srvs::Empty srv; stop_srv.call(srv); }
+
+private:
+  ros::NodeHandle nh;
+  ros::Publisher cmd_pub;
+  ros::Subscriber odom_sub;
+  nav_msgs::Odometry last_odom;
+
+  ros::ServiceClient start_srv;
+  ros::ServiceClient stop_srv;
+
+  void odomCallback(const nav_msgs::Odometry& odom)
+  {
+    ROS_INFO_STREAM("Callback reveived: pos.x: " << odom.pose.pose.position.x
+                     << ", orient.z: " << odom.pose.pose.orientation.z
+                     << ", lin_est: " << odom.twist.twist.linear.x
+                     << ", ang_est: " << odom.twist.twist.angular.z);
+    last_odom = odom;
+  }
+};
+
+inline tf::Quaternion tfQuatFromGeomQuat(const geometry_msgs::Quaternion& quat)
+{
+  return tf::Quaternion(quat.x, quat.y, quat.z, quat.w);
+}

--- a/steer_drive_controller/test/common/launch/steer_drive_common.launch
+++ b/steer_drive_controller/test/common/launch/steer_drive_common.launch
@@ -1,0 +1,28 @@
+<launch>
+  <!-- Load steerbot model -->
+  <param name="robot_description"
+      command="$(find xacro)/xacro.py '$(find steer_drive_controller)/test/common/urdf/steerbot.xacro'" />
+
+  <!-- Load controller config -->
+  <rosparam command="load" file="$(find steer_drive_controller)/test/common/config/steerbot_controllers.yaml" />
+
+  <!-- Start steerbot -->
+  <node name="steerbot"
+      pkg="steer_drive_controller"
+      type="steerbot"/>
+
+  <!-- Spawn controller -->
+  <node name="controller_spawner"
+        pkg="controller_manager" type="spawner" output="screen"
+        args="steerbot_controller" />
+
+  <!-- rqt_plot monitoring -->
+  <node name="steerbot_pos_monitor"
+        pkg="rqt_plot"
+        type="rqt_plot"
+        args="/steerbot_controller/odom/pose/pose/position/x" />
+  <node name="steerbot_vel_monitor"
+        pkg="rqt_plot"
+        type="rqt_plot"
+        args="/steerbot_controller/odom/twist/twist/linear/x" />
+</launch>

--- a/steer_drive_controller/test/common/launch/steer_drive_common.launch
+++ b/steer_drive_controller/test/common/launch/steer_drive_common.launch
@@ -1,15 +1,15 @@
 <launch>
   <!-- Load steerbot model -->
   <param name="robot_description"
-      command="$(find xacro)/xacro.py '$(find steer_drive_controller)/test/common/urdf/steerbot.xacro'" />
+         command="$(find xacro)/xacro.py '$(find steer_drive_controller)/test/common/urdf/steerbot.xacro'" />
 
   <!-- Load controller config -->
   <rosparam command="load" file="$(find steer_drive_controller)/test/common/config/steerbot_controllers.yaml" />
 
   <!-- Start steerbot -->
   <node name="steerbot"
-      pkg="steer_drive_controller"
-      type="steerbot"/>
+        pkg="steer_drive_controller"
+        type="steerbot"/>
 
   <!-- Spawn controller -->
   <node name="controller_spawner"
@@ -17,6 +17,7 @@
         args="steerbot_controller" />
 
   <!-- rqt_plot monitoring -->
+  <!--
   <node name="steerbot_pos_monitor"
         pkg="rqt_plot"
         type="rqt_plot"
@@ -25,4 +26,5 @@
         pkg="rqt_plot"
         type="rqt_plot"
         args="/steerbot_controller/odom/twist/twist/linear/x" />
+  -->
 </launch>

--- a/steer_drive_controller/test/common/launch/view_steerbot.launch
+++ b/steer_drive_controller/test/common/launch/view_steerbot.launch
@@ -1,0 +1,25 @@
+<launch>
+  <!-- start world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch"/>
+
+  <!-- load robot -->
+  <param name="robot_description"
+      command="$(find xacro)/xacro.py '$(find steer_drive_controller)/test/common/urdf/steerbot.xacro'" />
+
+  <!-- Load controller config -->
+  <rosparam command="load" file="$(find steer_drive_controller)/test/common/config/steerbot_controllers.yaml" />
+
+  <!-- Start steerbot -->
+  <node name="steerbot"
+      pkg="steer_drive_controller"
+      type="steerbot"/>
+
+  <!-- Spawn controller -->
+  <node name="controller_spawner"
+        pkg="controller_manager" type="spawner" output="screen"
+        args="steerbot_controller" />
+
+  <!-- push robot_description to factory and spawn robot in gazebo -->
+  <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
+	args="-urdf -model steerbot -param robot_description -z 0.5"/>
+</launch>

--- a/steer_drive_controller/test/common/src/steerbot.cpp
+++ b/steer_drive_controller/test/common/src/steerbot.cpp
@@ -1,0 +1,61 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// NOTE: The contents of this file have been taken largely from the ros_control wiki tutorials
+
+// ROS
+#include <ros/ros.h>
+
+// ros_control
+#include <controller_manager/controller_manager.h>
+
+#include "./../include/steerbot.h"
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "steerbot");
+  ros::NodeHandle nh;
+
+  Steerbot robot;
+  ROS_WARN_STREAM("period: " << robot.getPeriod().toSec());
+  controller_manager::ControllerManager cm(&robot, nh);
+
+  ros::Rate rate(1.0 / robot.getPeriod().toSec());
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  while(ros::ok())
+  {
+    ROS_WARN_STREAM("period: " << robot.getPeriod().toSec());
+    robot.read();
+    cm.update(robot.getTime(), robot.getPeriod());
+    robot.write();
+    rate.sleep();
+  }
+  spinner.stop();
+
+  return 0;
+}

--- a/steer_drive_controller/test/common/urdf/steerbot.xacro
+++ b/steer_drive_controller/test/common/urdf/steerbot.xacro
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<!--
+Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF-Controller%20Example
+-->
+  <xacro:include filename="$(find steer_drive_controller)/test/common/urdf/wheel.xacro"/>
+
+  <xacro:property name="deg_to_rad" value="0.01745329251994329577"/>
+
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="length" value="0.5" /> 
+  <xacro:property name="width" value="0.3" /> 
+  <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
+  <xacro:property name="thickness" value="0.086" /> <!-- Link 2 -->
+  <xacro:property name="axel_offset" value="0.05" /> <!-- Space btw top of beam and the each joint -->
+  <xacro:property name="steer_offset" value="0.02" /> <!-- Link 1 -->
+
+  <!-- Links: inertial,visual,collision -->
+  <link name="base_link">
+    <inertial>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="5"/>
+      <inertia ixx="5" ixy="0" ixz="0" iyy="5" iyz="0" izz="5"/>
+    </inertial>
+    <visual>
+      <geometry>
+        <box size="${length} ${width} 0.1"/>
+      </geometry>
+    </visual>
+    <collision>
+      <!-- origin is relative -->
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <box size="${length} ${width} 0.1"/>
+      </geometry>
+    </collision>
+  </link>
+
+
+  <link name="base_footprint">
+    <visual>
+      <geometry>
+        <sphere radius="0.01"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0"/>
+      <geometry>
+        <sphere radius="0.00000001"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="base_footprint_joint" type="fixed">
+    <origin xyz="0 0 ${wheel_radius}" rpy="0 0 0"/>
+    <child link="base_link"/>
+    <parent link="base_footprint"/>
+  </joint>
+
+
+  <!-- Wheels -->
+  <front_wheel name="front_right" parent="base" radius="${wheel_radius}" thickness="${thickness}" 
+      length="${length}" width="${width}" axel_offset="${axel_offset}" right_left="1" steer_height="${wheel_radius+steer_offset}">
+    <origin xyz="${length/2-axel_offset} ${width/2+axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </front_wheel>
+  <front_wheel name="front_left" parent="base" radius="${wheel_radius}" thickness="${thickness}" 
+      length="${length}" width="${width}" axel_offset="${axel_offset}" right_left="-1" steer_height="${wheel_radius+steer_offset}">
+    <origin xyz="${length/2-axel_offset} ${-width/2-axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </front_wheel>
+  <rear_wheel name="rear_right" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${-length/2+axel_offset} ${width/2+axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </rear_wheel>
+  <rear_wheel name="rear_left" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+    <origin xyz="${-length/2+axel_offset} ${-width/2-axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
+  </rear_wheel>
+
+
+  <!-- Colour -->
+  <gazebo reference="base_link">
+    <material>Gazebo/Green</material>
+  </gazebo>
+
+  <gazebo reference="base_footprint">
+    <material>Gazebo/Purple</material>
+  </gazebo>
+
+</robot>

--- a/steer_drive_controller/test/common/urdf/wheel.xacro
+++ b/steer_drive_controller/test/common/urdf/wheel.xacro
@@ -1,0 +1,129 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="steer_radius" value="0.05" /> <!-- Link 1 -->
+  <xacro:property name="steer_thickness" value="0.02" /> <!-- Link 1 -->
+  <xacro:property name="steer_effort"   value="10.0"/>
+  <xacro:property name="steer_velocity" value="5.0"/>
+
+  <macro name="front_wheel" params="name parent radius thickness length width axel_offset right_left steer_height *origin">
+    <link name="${name}_steer_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="1"/>
+        <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${steer_radius}" length="${steer_thickness}"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${steer_radius}" length="${steer_thickness}"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${name}_steer_joint" type="revolute">
+      <parent link="${parent}_link"/>
+      <child link="${name}_steer_link"/>
+      <origin xyz="${length/2-axel_offset} ${right_left*(width/2+axel_offset)} ${steer_height}" rpy="0 0 0"/>
+      <!--insert_block name="origin"/-->
+      <axis xyz="0 0 1"/>
+      <limit effort="${steer_effort}"
+             lower="${-180.0 * deg_to_rad}" upper="${180.0 * deg_to_rad}"
+             velocity="${steer_velocity}"/>
+     </joint>
+
+    <link name="${name}_wheel_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="1"/>
+        <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${name}_wheel_joint" type="continuous">
+      <parent link="${name}_steer_link"/>
+      <child link="${name}_wheel_link"/>
+      <origin xyz="0 0 ${-steer_height}" rpy="${-90 * deg_to_rad} 0 0"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+
+    <!-- Transmission is important to link the joints and the controller -->
+    <transmission name="${name}_steer_joint_trans" type="SimpleTransmission">
+      <actuator name="${name}_steer_joint_motor"/>
+      <joint name="${name}_steer_joint"/>
+      <mechanicalReduction>1</mechanicalReduction>
+      <motorTorqueConstant>1</motorTorqueConstant>
+    </transmission>
+    <transmission name="${name}_wheel_joint_trans" type="SimpleTransmission">
+      <actuator name="${name}_wheel_joint_motor"/>
+      <joint name="${name}_wheel_joint"/>
+      <mechanicalReduction>1</mechanicalReduction>
+      <motorTorqueConstant>1</motorTorqueConstant>
+    </transmission>
+
+    <gazebo reference="${name}_steer_link">
+      <material>Gazebo/Blue</material>
+    </gazebo>
+    <gazebo reference="${name}_wheel_link">
+      <material>Gazebo/Red</material>
+    </gazebo>
+  </macro>
+
+  <macro name="rear_wheel" params="name parent radius thickness *origin">
+    <link name="${name}_wheel_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="1"/>
+        <inertia ixx="0.2" ixy="0" ixz="0" iyy="0.2" iyz="0" izz="0.2"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <cylinder radius="${wheel_radius}" length="${thickness}"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${name}_wheel_joint" type="continuous">
+      <parent link="${parent}_link"/>
+      <child link="${name}_wheel_link"/>
+      <insert_block name="origin"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+
+    <!-- Transmission is important to link the joints and the controller -->
+    <transmission name="${name}_wheel_joint_trans" type="SimpleTransmission">
+      <actuator name="${name}_wheel_joint_motor"/>
+      <joint name="${name}_wheel_joint"/>
+      <mechanicalReduction>1</mechanicalReduction>
+      <motorTorqueConstant>1</motorTorqueConstant>
+    </transmission>
+
+    <gazebo reference="${name}_wheel_link">
+      <material>Gazebo/Red</material>
+    </gazebo>
+  </macro>
+</robot>

--- a/steer_drive_controller/test/steer_drive_controller.test
+++ b/steer_drive_controller/test/steer_drive_controller.test
@@ -1,0 +1,13 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find steer_drive_controller)/test/common/launch/steer_drive_common.launch" />
+
+  <!-- Controller test -->
+  <test test-name="steer_drive_test"
+        pkg="steer_drive_controller"
+        type="steer_drive_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="steerbot_controller/cmd_vel" />
+    <remap from="odom" to="steerbot_controller/odom" />
+  </test>
+</launch>

--- a/steer_drive_controller/test/steer_drive_controller_nan.test
+++ b/steer_drive_controller/test/steer_drive_controller_nan.test
@@ -1,0 +1,14 @@
+
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find steer_drive_controller)/test/common/launch/steer_drive_common.launch" />
+
+  <!-- Controller test -->
+  <test test-name="steer_drive_nan_test"
+        pkg="steer_drive_controller"
+        type="steer_drive_nan_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="steerbot_controller/cmd_vel" />
+    <remap from="odom" to="steerbot_controller/odom" />
+  </test>
+</launch>

--- a/steer_drive_controller/test/steer_drive_nan_test.cpp
+++ b/steer_drive_controller/test/steer_drive_nan_test.cpp
@@ -1,0 +1,92 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2014, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Enrique Fernandez
+
+#include "./common/include/test_common.h"
+
+// NaN
+#include <limits>
+
+// TEST CASES
+TEST_F(SteerDriveControllerTest, testNaN)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(2.0).sleep();
+
+  // send a command
+  cmd_vel.linear.x = 0.1;
+  ros::Duration(2.0).sleep();
+
+  // stop robot (will generate NaN)
+  stop();
+  ros::Duration(2.0).sleep();
+
+  nav_msgs::Odometry odom = getLastOdom();
+
+  EXPECT_NE(std::isnan(odom.twist.twist.linear.x), true);
+  EXPECT_NE(std::isnan(odom.twist.twist.angular.z), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.position.x), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.position.y), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.orientation.z), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.orientation.w), true);
+
+  // start robot
+  start();
+  ros::Duration(2.0).sleep();
+
+  odom = getLastOdom();
+
+  EXPECT_NE(std::isnan(odom.twist.twist.linear.x), true);
+  EXPECT_NE(std::isnan(odom.twist.twist.angular.z), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.position.x), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.position.y), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.orientation.z), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.orientation.w), true);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "steer_drive_nan_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/steer_drive_controller/test/steer_drive_test.cpp
+++ b/steer_drive_controller/test/steer_drive_test.cpp
@@ -1,472 +1,155 @@
-#include<stdio.h>
-#include<iostream>
-#include<ros/ros.h>
-#include<steer_drive_controller/steer_drive_controller.h>
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
 
-// ros_control
-#include <controller_manager/controller_manager.h>
-#include <hardware_interface/joint_command_interface.h>
-// gazebo
-#include <control_toolbox/pid.h>
-#include <gazebo_ros_control/robot_hw_sim.h>
-#include <gazebo/gazebo.hh>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/common/common.hh>
+/// \author Bence Magyar
 
-int configureVelocityJointInterface(hardware_interface::VelocityJointInterface&);
+#include "./common/include/test_common.h"
+#include <tf/transform_listener.h>
 
-class SteerBot:
-        //public gazebo_ros_control::RobotHWSim
-        public hardware_interface::RobotHW
+// TEST CASES
+TEST_F(SteerDriveControllerTest, testForward)
 {
-    // constant
-private:
-    enum {
-        INDEX_RIGHT = 0,
-        INDEX_LEFT = 1
-    };
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+  // get initial odom
+  nav_msgs::Odometry old_odom = getLastOdom();
+  // send a velocity command of 0.1 m/s
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  // wait for 10s
+  ros::Duration(10.0).sleep();
 
-    // methods
-public:
-    SteerBot(ros::NodeHandle &_nh)
-        : ns_("steer_drive_controller/")
-    {
-        this->CleanUp();
-        this->GetJointNames(_nh);
-#ifdef MULTIPLE_JOINTS
-        this->Resize();
-#endif
-        this->RegisterHardwareInterfaces();
-    }
+  nav_msgs::Odometry new_odom = getLastOdom();
 
-    bool initSim(const std::string& _robot_namespace,
-      ros::NodeHandle _nh,
-      gazebo::physics::ModelPtr _model,
-      const urdf::Model* const _urdf_model,
-      std::vector<transmission_interface::TransmissionInfo> _transmissions)
-    {
-        using gazebo::physics::JointPtr;
+  // check if the robot traveled 1 meter in XY plane, changes in z should be ~~0
+  const double dx = new_odom.pose.pose.position.x - old_odom.pose.pose.position.x;
+  const double dy = new_odom.pose.pose.position.y - old_odom.pose.pose.position.y;
+  const double dz = new_odom.pose.pose.position.z - old_odom.pose.pose.position.z;
+  EXPECT_NEAR(sqrt(dx*dx + dy*dy), 1.0, POSITION_TOLERANCE);
+  EXPECT_LT(fabs(dz), EPS);
 
-        this->CleanUp();
+  // convert to rpy and test that way
+  double roll_old, pitch_old, yaw_old;
+  double roll_new, pitch_new, yaw_new;
+  tf::Matrix3x3(tfQuatFromGeomQuat(old_odom.pose.pose.orientation)).getRPY(roll_old, pitch_old, yaw_old);
+  tf::Matrix3x3(tfQuatFromGeomQuat(new_odom.pose.pose.orientation)).getRPY(roll_new, pitch_new, yaw_new);
+  EXPECT_LT(fabs(roll_new - roll_old), EPS);
+  EXPECT_LT(fabs(pitch_new - pitch_old), EPS);
+  EXPECT_LT(fabs(yaw_new - yaw_old), EPS);
+  EXPECT_NEAR(fabs(new_odom.twist.twist.linear.x), cmd_vel.linear.x, EPS);
+  EXPECT_LT(fabs(new_odom.twist.twist.linear.y), EPS);
+  EXPECT_LT(fabs(new_odom.twist.twist.linear.z), EPS);
 
-        // simulation joints
-        sim_joints_ = _model->GetJoints();
-        int n_dof = sim_joints_.size();
+  EXPECT_LT(fabs(new_odom.twist.twist.angular.x), EPS);
+  EXPECT_LT(fabs(new_odom.twist.twist.angular.y), EPS);
+  EXPECT_LT(fabs(new_odom.twist.twist.angular.z), EPS);
+}
 
-#ifdef MULTIPLE_JOINTS
-        this->GetJointNames(_nh);
-        this->Resize();
-#endif
-        this->RegisterHardwareInterfaces();
-    }
-
-    void readSim(ros::Time time, ros::Duration period)
-    {
-
-    }
-
-    void writeSim(ros::Time time, ros::Duration period)
-    {
-
-    }
-
-    void read()
-    {
-        std::ostringstream os;
-
-#ifdef MULTIPLE_JOINTS
-        for (unsigned int i = 0; i < cnt_wheel_joints_ - 1; ++i)
-        {
-            os << wheel_joint_vel_cmd_[i] << ", ";
-        }
-        os << wheel_joint_vel_cmd_[cnt_wheel_joints_ - 1];
-#endif
-        os << wheel_jnt_vel_cmd_;
-
-        ROS_INFO_STREAM("Commands for wheel joints: " << os.str());
-    }
-
-    ros::Duration getPeriod() const {return ros::Duration(0.01);}
-
-    void write()
-    {
-        bool running_ = true;
-        if (running_)
-        {
-#ifdef MULTIPLE_JOINTS
-            for (unsigned int i = 0; i < cnt_wheel_joints_; ++i)
-            {
-                // Note that pos_[i] will be NaN for one more cycle after we start(),
-                // but that is consistent with the knowledge we have about the state
-                // of the robot.
-                wheel_joint_pos_[i] += wheel_joint_vel_[i]*getPeriod().toSec(); // update position
-                wheel_joint_vel_[i] = wheel_joint_vel_cmd_[i]; // might add smoothing here later
-            }
-#endif
-            wheel_jnt_pos_ += wheel_jnt_vel_ * getPeriod().toSec(); // update position
-            wheel_jnt_vel_ = wheel_jnt_vel_cmd_;
-            steer_jnt_pos_ = steer_jnt_pos_cmd_;
-
-            const int n_dof = sim_joints_.size();
-            for(int i = 0; i < n_dof; i++)
-            {
-                std::string gazebo_jnt_name;
-                /*
-                gazebo_jnt_name = sim_joints_[i]->GetName();
-                */
-                if(gazebo_jnt_name == virtual_wheel_jnt_names_[INDEX_RIGHT])
-                {
-                    //sim_joints_[i]->SetVelocity(0, wheel_jnt_vel_cmd_);
-                }
-                else if(gazebo_jnt_name == virtual_wheel_jnt_names_[INDEX_LEFT])
-                {
-                    //sim_joints_[i]->SetVelocity(0, -1 * wheel_jnt_vel_cmd_);
-                }
-                else if(gazebo_jnt_name == virtual_steer_jnt_names_[INDEX_RIGHT])
-                {
-                    //sim_joints_[i]->SetAngle(0, steer_jnt_pos_cmd_);
-                }
-                else if(gazebo_jnt_name == virtual_steer_jnt_names_[INDEX_LEFT])
-                {
-                    //sim_joints_[i]->SetAngle(0, steer_jnt_pos_cmd_);
-                }
-                else
-                {
-                    // do nothing
-                }
-
-            }
-        }
 #if 0
-        else
-        {
-            std::fill_n(joint_pos_, cnt_wheel_joints_, std::numeric_limits<double>::quiet_NaN());
-            std::fill_n(joint_vel_, cnt_wheel_joints_, std::numeric_limits<double>::quiet_NaN());
-        }
-#endif
-    }
-private:
-    void CleanUp()
-    {
-#ifdef MULTIPLE_JOINTS
-        // wheel joints
-        wheel_joint_names_.clear();
-        wheel_joint_pos_.clear();
-        wheel_joint_vel_.clear();
-        wheel_joint_eff_.clear();
-        wheel_joint_vel_cmd_.clear();
-#endif
-
-        // wheel joint names
-        wheel_jnt_name_.empty();
-        virtual_wheel_jnt_names_.clear();
-        // rear wheel joint
-        wheel_jnt_pos_ = 0;
-        wheel_jnt_vel_ = 0;
-        wheel_jnt_eff_ = 0;
-        wheel_jnt_vel_cmd_ = 0;
-
-#ifdef MULTIPLE_JOINTS
-        // steer joints
-        steer_joint_names_.clear();
-        steer_joint_pos_.clear();
-        steer_joint_vel_.clear();
-        steer_joint_eff_.clear();
-        steer_joint_vel_cmd_.clear();
-#endif
-
-        // steer joint names
-        steer_jnt_name_.empty();
-        virtual_steer_jnt_names_.clear();
-        // front steer joint
-        steer_jnt_pos_ = 0;
-        steer_jnt_vel_ = 0;
-        steer_jnt_eff_ = 0;
-        steer_jnt_pos_cmd_ = 0;
-
-    }
-
-#ifdef MULTIPLE_JOINTS
-    void Resize()
-    {
-       // wheel joints
-       wheel_joint_pos_.resize(cnt_wheel_joints_);
-       wheel_joint_vel_.resize(cnt_wheel_joints_);
-       wheel_joint_eff_.resize(cnt_wheel_joints_);
-       wheel_joint_vel_cmd_.resize(cnt_wheel_joints_);
-
-       // steer joints
-       steer_joint_pos_.resize(cnt_steer_joints_);
-       steer_joint_vel_.resize(cnt_steer_joints_);
-       steer_joint_eff_.resize(cnt_steer_joints_);
-       steer_joint_vel_cmd_.resize(cnt_steer_joints_);
-    }
-#endif
-    void GetJointNames(ros::NodeHandle &_nh)
-    {
-        this->GetWheelJointNames(_nh);
-        this->GetSteerJointNames(_nh);
-    }
-
-    void GetWheelJointNames(ros::NodeHandle &_nh)
-    {
-        // wheel joint to get linear command
-        _nh.getParam(ns_ + "rear_wheel", wheel_jnt_name_);
-
-        // virtual wheel joint for gazebo control
-        std::vector<std::string> virtual_wheel_jnt_names;
-
-        _nh.getParam(ns_ + "gazebo/virtual_rear_wheel", virtual_wheel_jnt_names);
-
-        virtual_wheel_jnt_names_ = virtual_wheel_jnt_names;
-        cnt_virtual_wheel_joints_ = virtual_wheel_jnt_names_.size();
-    }
-
-    void GetSteerJointNames(ros::NodeHandle &_nh)
-    {
-        // steer joint to get angular command
-        _nh.getParam(ns_ + "front_steer", steer_jnt_name_);
-
-        // virtual steer joint for gazebo control
-        std::vector<std::string> virtual_steer_jnt_names;
-
-        _nh.getParam(ns_ + "gazebo/virtual_front_steer", virtual_steer_jnt_names);
-
-        virtual_steer_jnt_names_ = virtual_steer_jnt_names;
-        cnt_virtual_steer_joints_ = virtual_steer_jnt_names_.size();
-    }
-
-#ifdef MULTIPLE_JOINTS
-    void GetWheelJointNames(ros::NodeHandle &_nh)
-    {
-        // wheel names
-        std::vector<std::string> right_wheel_joint_names;
-        std::vector<std::string> left_wheel_joint_names;
-
-        _nh.getParam(ns_ + "right_wheel", right_wheel_joint_names);
-        _nh.getParam(ns_ + "left_wheel", left_wheel_joint_names);
-
-        wheel_joint_names_ = right_wheel_joint_names;
-        std::copy(left_wheel_joint_names.begin(), left_wheel_joint_names.end(),
-                  std::back_inserter(wheel_joint_names_));
-        cnt_wheel_joints_ = wheel_joint_names_.size();
-
-        // rear wheel name
-        std::string wheel_joint_name;
-        /*
-        _nh.getParam(ns_ + "rear_wheel", wheel_joint_name);
-        wheel_joint_name_ = wheel_joint_name;
-        */
-    }
-
-    void GetSteerJointNames(ros::NodeHandle &_nh)
-    {
-        // steer names
-        std::vector<std::string> right_steer_joint_names;
-        std::vector<std::string> left_steer_joint_names;
-
-        _nh.getParam(ns_ + "right_steer", right_steer_joint_names);
-        _nh.getParam(ns_ + "left_steer", left_steer_joint_names);
-
-        steer_joint_names_ = right_steer_joint_names;
-        std::copy(left_steer_joint_names.begin(), left_steer_joint_names.end(),
-                  std::back_inserter(steer_joint_names_));
-        cnt_steer_joints_ = steer_joint_names_.size();
-
-        // front steer name
-        std::string steer_joint_name;
-        /*
-        _nh.getParam(ns_ + "front_steer", steer_joint_name);
-        wheel_joint_name_ = steer_joint_name;
-        */
-    }
-#endif
-
-    void RegisterHardwareInterfaces()
-    {
-#ifdef MULTIPLE_JOINTS
-        this->RegisterSteerInterfaces();
-#endif
-        this->RegisterSteerInterface();
-
-#ifdef MULTIPLE_JOINTS
-        this->RegisterWheelInterfaces();
-#endif
-        this->RegisterWheelInterface();
-    }
-
-    void RegisterWheelInterface()
-    {
-        hardware_interface::JointStateHandle state_handle_steer(wheel_jnt_name_,
-                                                                &wheel_jnt_pos_,
-                                                                &wheel_jnt_vel_,
-                                                                &wheel_jnt_eff_);
-        wheel_joint_state_interface_.registerHandle(state_handle_steer);
-        // joint velocity command
-        hardware_interface::JointHandle vel_handle(wheel_joint_state_interface_.getHandle(wheel_jnt_name_),
-                                                   &wheel_jnt_vel_cmd_);
-        wheel_vel_joint_interface_.registerHandle(vel_handle);
-
-        ROS_DEBUG_STREAM("Registered joint '" << wheel_jnt_name_ << " ' in the VelocityJointInterface");
-
-        // register mapped interface to ros_control
-        registerInterface(&wheel_joint_state_interface_);
-        registerInterface(&wheel_vel_joint_interface_);
-    }
-
-#ifdef MULTIPLE_JOINTS
-    void RegisterWheelInterfaces()
-    {
-        // map members to hardware interfaces
-        for (size_t i = 0; i < cnt_wheel_joints_; ++i) {
-            // joint states
-            hardware_interface::JointStateHandle state_handle(virtual_wheel_jnt_names_[i],
-                                                              &wheel_joint_pos_[i],
-                                                              &wheel_joint_vel_[i],
-                                                              &wheel_joint_eff_[i]);
-            wheel_joint_state_interface_.registerHandle(state_handle);
-
-            // joint velocity command
-            hardware_interface::JointHandle vel_handle(wheel_joint_state_interface_.getHandle(virtual_wheel_jnt_names_[i]),
-                                                       &wheel_joint_vel_cmd_[i]);
-            wheel_vel_joint_interface_.registerHandle(vel_handle);
-
-            ROS_DEBUG_STREAM("Registered joint '" << virtual_wheel_jnt_names_[i] << " ' in the VelocityJointInterface");
-        }
-
-        // register mapped interface to ros_control
-        registerInterface(&wheel_joint_state_interface_);
-        registerInterface(&wheel_vel_joint_interface_);
-    }
-#endif
-    void RegisterSteerInterface()
-    {
-        hardware_interface::JointStateHandle state_handle_wheel(steer_jnt_name_,
-                                                                &steer_jnt_pos_,
-                                                                &steer_jnt_vel_,
-                                                                &steer_jnt_eff_);
-        steer_joint_state_interface_.registerHandle(state_handle_wheel);
-
-        // joint position command
-        hardware_interface::JointHandle pos_handle(steer_joint_state_interface_.getHandle(steer_jnt_name_),
-                                                   &steer_jnt_pos_cmd_);
-        steer_pos_joint_interface_.registerHandle(pos_handle);
-
-        ROS_DEBUG_STREAM("Registered joint '" << steer_jnt_name_ << " ' in the PositionJointInterface");
-
-        // register mapped interface to ros_control
-        registerInterface(&steer_joint_state_interface_);
-        registerInterface(&steer_pos_joint_interface_);
-    }
-
-#ifdef MULTIPLE_JOINTS
-    void RegisterSteerInterfaces()
-    {
-        // map members to hardware interfaces
-        for (size_t i = 0; i < cnt_steer_joints_; ++i) {
-            // joint states
-            hardware_interface::JointStateHandle state_handle(virtual_steer_jnt_names_[i],
-                                                              &steer_joint_pos_[i],
-                                                              &steer_joint_vel_[i],
-                                                              &steer_joint_eff_[i]);
-            steer_joint_state_interface_.registerHandle(state_handle);
-
-            // joint position command
-            hardware_interface::JointHandle pos_handle(steer_joint_state_interface_.getHandle(virtual_steer_jnt_names_[i]),
-                                                       &steer_joint_vel_cmd_[i]);
-            steer_pos_joint_interface_.registerHandle(pos_handle);
-
-            ROS_DEBUG_STREAM("Registered joint '" << virtual_steer_jnt_names_[i] << " ' in the PositionJointInterface");
-        }
-
-        // register mapped interface to ros_control
-        registerInterface(&steer_joint_state_interface_);
-        registerInterface(&steer_pos_joint_interface_);
-    }
-#endif
-    // member variables
-public:
-    hardware_interface::VelocityJointInterface wheel_vel_joint_interface_;
-    hardware_interface::PositionJointInterface steer_pos_joint_interface_;
-
-private:
-    ros::NodeHandle nh_;
-
-    std::string ns_;
-    //
-    std::vector<std::string> virtual_wheel_jnt_names_;
-    std::vector<std::string> virtual_steer_jnt_names_;
-    std::string wheel_jnt_name_;
-    std::string steer_jnt_name_;
-
-    // interface variables
-    //-- wheel
-    int cnt_virtual_wheel_joints_;
-    std::vector<double> wheel_joint_pos_;
-    std::vector<double> wheel_joint_vel_;
-    std::vector<double> wheel_joint_eff_;
-    std::vector<double> wheel_joint_vel_cmd_;
-    //-- rear wheel
-    double wheel_jnt_pos_;
-    double wheel_jnt_vel_;
-    double wheel_jnt_eff_;
-    double wheel_jnt_vel_cmd_;
-
-    //-- steer
-    int cnt_virtual_steer_joints_;
-    std::vector<double> steer_joint_pos_;
-    std::vector<double> steer_joint_vel_;
-    std::vector<double> steer_joint_eff_;
-    std::vector<double> steer_joint_vel_cmd_;
-    //-- front steer
-    double steer_jnt_pos_;
-    double steer_jnt_vel_;
-    double steer_jnt_eff_;
-    double steer_jnt_pos_cmd_;
-
-    //
-    hardware_interface::JointStateInterface wheel_joint_state_interface_;
-    hardware_interface::JointStateInterface steer_joint_state_interface_;
-
-    // gazebo
-    std::vector<gazebo::physics::JointPtr> sim_joints_;
-    // PID Controller
-    std::vector<control_toolbox::Pid> pids_;
-
-};
-
-int main(int argc, char **argv)
+TEST_F(SteerDriveControllerTest, testTurn)
 {
-    ros::init(argc, argv, "steer_drive_test");
-    ros::NodeHandle nh_main;
-    ros::NodeHandle nh_control;
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+  // get initial odom
+  nav_msgs::Odometry old_odom = getLastOdom();
+  // send a velocity command
+  cmd_vel.angular.z = M_PI/10.0;
+  publish(cmd_vel);
+  // wait for 10s
+  ros::Duration(10.0).sleep();
 
-    SteerBot* steer_drive_bot = new SteerBot(nh_control);
+  nav_msgs::Odometry new_odom = getLastOdom();
 
-    steer_drive_controller::SteerDriveController rb_controller;
-#if 0
-    bool rt_code = rb_controller.init(//&steer_drive_bot->wheel_vel_joint_interface_,
-                                      steer_drive_bot,
-                                      nh_main, nh_control);
+  // check if the robot rotated PI around z, changes in the other fields should be ~~0
+  EXPECT_LT(fabs(new_odom.pose.pose.position.x - old_odom.pose.pose.position.x), EPS);
+  EXPECT_LT(fabs(new_odom.pose.pose.position.y - old_odom.pose.pose.position.y), EPS);
+  EXPECT_LT(fabs(new_odom.pose.pose.position.z - old_odom.pose.pose.position.z), EPS);
+
+  // convert to rpy and test that way
+  double roll_old, pitch_old, yaw_old;
+  double roll_new, pitch_new, yaw_new;
+  tf::Matrix3x3(tfQuatFromGeomQuat(old_odom.pose.pose.orientation)).getRPY(roll_old, pitch_old, yaw_old);
+  tf::Matrix3x3(tfQuatFromGeomQuat(new_odom.pose.pose.orientation)).getRPY(roll_new, pitch_new, yaw_new);
+  EXPECT_LT(fabs(roll_new - roll_old), EPS);
+  EXPECT_LT(fabs(pitch_new - pitch_old), EPS);
+  EXPECT_NEAR(fabs(yaw_new - yaw_old), M_PI, ORIENTATION_TOLERANCE);
+
+  EXPECT_LT(fabs(new_odom.twist.twist.linear.x), EPS);
+  EXPECT_LT(fabs(new_odom.twist.twist.linear.y), EPS);
+  EXPECT_LT(fabs(new_odom.twist.twist.linear.z), EPS);
+
+  EXPECT_LT(fabs(new_odom.twist.twist.angular.x), EPS);
+  EXPECT_LT(fabs(new_odom.twist.twist.angular.y), EPS);
+  EXPECT_NEAR(fabs(new_odom.twist.twist.angular.z), M_PI/10.0, EPS);
+}
 #endif
-    std::set<std::string> claimed_resources; // Gets populated during initRequest call
-    bool rt_code = rb_controller.init(steer_drive_bot, nh_main, nh_control);//, claimed_resources);
 
-    ros::Rate rate(100);
-    ros::Time last_time = ros::Time::now();
+TEST_F(SteerDriveControllerTest, testOdomFrame)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // set up tf listener
+  tf::TransformListener listener;
+  ros::Duration(2.0).sleep();
+  // check the odom frame exist
+  EXPECT_TRUE(listener.frameExists("odom"));
+}
 
-    while(nh_main.ok())
-    {
-        ros::Time now = ros::Time::now();
-        ros::Duration period = now - last_time;
-        last_time = now;
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "steer_drive_test");
 
-        steer_drive_bot->read();
-        rb_controller.update(now, period);
-        steer_drive_bot->write();
-
-        ros::spinOnce();
-        rate.sleep();
-    }
-    return 0;
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  //ros::Duration(0.5).sleep();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
 }


### PR DESCRIPTION
https://github.com/CIR-KIT/steer_drive_ros/issues/8#issuecomment-263626667 のコメントを受けて．

移行途中ですが，まずはベースをこちらに移しておきます．

なお，gtestが入っている時は，`catkin_make run_tests`を実行しないとテストコードがビルドされないようなので，ご注意下さい．
一度ビルドすれば，`catkin_make test`で確認できます．

`test`と`run_tests`について，これまでの経緯から考えると，下記のように状況によって使い分けるのが良さげです．

- `catkin_make run_tests`
  * 初回ビルド時はこちらが必須．
  * どのテストが失敗したのかがパッと見てわかりづらい．
  * ただし，エラーログが詳細で，テスト別の実行もできるので，デバッグ時はこちら便利．
- `catkin_make test`
  * テスト全体の視認性が非常に良い．
  * 一度ビルドしたあとなら，普段使いのチェック用にするのが良さげ．
  * こちらでエラーを吐いたテストは，`catkin_make run_tests`側で詳細にデバッグ．