### PR TITLE
Add support for Gazebo9

### DIFF
--- a/steer_bot_hardware_gazebo/src/steer_bot_hardware_gazebo.cpp
+++ b/steer_bot_hardware_gazebo/src/steer_bot_hardware_gazebo.cpp
@@ -212,7 +212,11 @@ namespace steer_bot_hardware_gazebo
         {
           pos_cmd = front_steer_jnt_pos_cmd_;
         }
+#if GAZEBO_MAJOR_VERSION >= 9
+        sim_joints_[i]->SetPosition(0, pos_cmd, true);
+#else
         sim_joints_[i]->SetPosition(0, pos_cmd);
+#endif
       }
       else if(gazebo_jnt_name == virtual_front_steer_jnt_names_[INDEX_LEFT])
       {
@@ -228,7 +232,11 @@ namespace steer_bot_hardware_gazebo
         {
           pos_cmd = 2*front_steer_jnt_pos_cmd_;
         }
+#if GAZEBO_MAJOR_VERSION >= 9
+        sim_joints_[i]->SetPosition(0, pos_cmd, true);
+#else
         sim_joints_[i]->SetPosition(0, pos_cmd);
+#endif
       }
       else
       {
@@ -461,8 +469,13 @@ namespace steer_bot_hardware_gazebo
   void SteerBotHardwareGazebo::GetCurrentState(std::vector<double>& _jnt_pos, std::vector<double>& _jnt_vel, std::vector<double>& _jnt_eff,
                                                const int _if_index, const int _sim_jnt_index)
   {
+#if GAZEBO_MAJOR_VERSION >= 9
+    _jnt_pos[_if_index] +=
+        angles::shortest_angular_distance(_jnt_pos[_if_index], sim_joints_[_sim_jnt_index]->Position(0u));
+#else
     _jnt_pos[_if_index] +=
         angles::shortest_angular_distance(_jnt_pos[_if_index], sim_joints_[_sim_jnt_index]->GetAngle(0u).Radian());
+#endif
     _jnt_vel[_if_index] = sim_joints_[_sim_jnt_index]->GetVelocity(0u);
     _jnt_eff[_if_index] = sim_joints_[_sim_jnt_index]->GetForce(0u);
   }


### PR DESCRIPTION
This fixes the problem related to [Gazebo's position control](http://answers.gazebosim.org/question/15045/why-my-model-seems-to-defy-the-gravity-and-seems-to-be-grabbed-from-the-top-when-moving/?answer=15071#post-id-15071), which can be seen
[when dropping a position-controlled robot](https://github.com/turtlebot/turtlebot_arm/issues/22). The issue is fixed by using the
`_preserveWorldVelocity` argument introduced in Gazebo 9.0.0.

https://bitbucket.org/osrf/gazebo/pull-requests/2814/fix-issue-2111-by-providing-options-to/diff

Related issue/commit in gazebo_ros_pkgs, which introduces a similar fix:

https://github.com/ros-simulation/gazebo_ros_pkgs/commit/3164e4c6299407209a15fd87300f4364dc2e8063
https://github.com/ros-simulation/gazebo_ros_pkgs/issues/479
https://github.com/turtlebot/turtlebot_arm/issues/22

Tested on:

- ROS Lunar
- Gazebo 9.0.0

but [should work also on Gazebo 7](https://github.com/ros-simulation/gazebo_ros_pkgs/commit/3164e4c6299407209a15fd87300f4364dc2e8063):

> Tested on Gazebo7 (where it compiles, but doesn't change anything) and
> Gazebo9 (where it compiles and fixes the bug). I've tested it using the
> instructions I've put into this repo:

It seems like this PR also fixes the slippery wheels after upgrading to Kinetic. (Maybe related to https://github.com/CIR-KIT-Unit03/cirkit_unit03_simulator/issues/20)

\# @MoriKen254 さんのQiitaの記事，いつも読ませていただいてます！